### PR TITLE
Address managed pointer warnings to fix marshalling failure with InstallNullDriver on .NET Framework

### DIFF
--- a/src/PnP/PnPDevice.cs
+++ b/src/PnP/PnPDevice.cs
@@ -291,7 +291,7 @@ public partial class PnPDevice : IPnPDevice, IEquatable<PnPDevice>
                     HWND.Null,
                     hDevInfo,
                     &spDevinfoData,
-                    null,
+                    IntPtr.Zero,
                     PInvoke.DIIDFLAG_INSTALLNULLDRIVER,
                     out rebootRequired
                 );

--- a/src/PnP/SetupApi.cs
+++ b/src/PnP/SetupApi.cs
@@ -328,18 +328,6 @@ internal static class SetupApi
         out UInt32 requiredSize,
         [In] UInt32 flags
     );
-
-    [DllImport(nameof(SetupApi), CharSet = CharSet.Unicode, SetLastError = true)]
-    [return: MarshalAs(UnmanagedType.Bool)]
-    public static unsafe extern bool SetupDiGetDriverInfoDetail(
-        [In] HDEVINFO deviceInfoSet,
-        [In] [Optional] SP_DEVINFO_DATA* deviceInfoData,
-        [In] SP_DRVINFO_DATA* driverInfoData,
-        [In] [Out] SP_DRVINFO_DETAIL_DATA* driverInfoDetailData,
-        [In] uint driverInfoDetailDataSize,
-        [Out] [Optional] [SuppressMessage("ReSharper", "OptionalParameterRefOut")]
-        out uint requiredSize
-    );
     
     [DllImport(nameof(SetupApi), CharSet = CharSet.Unicode, SetLastError = true)]
     [return: MarshalAs(UnmanagedType.Bool)]
@@ -360,18 +348,6 @@ internal static class SetupApi
         [In] [Optional] SP_DEVINFO_DATA* deviceInfoData,
         [In] ref SP_DRVINFO_DATA driverInfoData,
         [In] [Out] IntPtr driverInfoDetailData,
-        [In] uint driverInfoDetailDataSize,
-        [Out] [Optional] [SuppressMessage("ReSharper", "OptionalParameterRefOut")]
-        out uint requiredSize
-    );
-    
-    [DllImport(nameof(SetupApi), CharSet = CharSet.Unicode, SetLastError = true)]
-    [return: MarshalAs(UnmanagedType.Bool)]
-    public static unsafe extern bool SetupDiGetDriverInfoDetail(
-        [In] HDEVINFO deviceInfoSet,
-        [In] [Optional] SP_DEVINFO_DATA* deviceInfoData,
-        [In] SP_DRVINFO_DATA* driverInfoData,
-        [In] [Out] ref SP_DRVINFO_DETAIL_DATA driverInfoDetailData,
         [In] uint driverInfoDetailDataSize,
         [Out] [Optional] [SuppressMessage("ReSharper", "OptionalParameterRefOut")]
         out uint requiredSize
@@ -428,9 +404,7 @@ internal static class SetupApi
         [In] [Optional] HWND hwndParent,
         [In] HDEVINFO deviceInfoSet,
         [In] SP_DEVINFO_DATA* deviceInfoData,
-#pragma warning disable CS8500
-        [In] [Optional] SP_DRVINFO_DATA* driverInfoData,
-#pragma warning restore CS8500
+        [In] [Optional] IntPtr driverInfoData,
         [In] uint flags,
         [Out] out bool needReboot
     );


### PR DESCRIPTION
Without this fix, calling InstallNullDriver will fail with a marshalling exception:

```
System.Runtime.InteropServices.MarshalDirectiveException: Cannot marshal 'parameter #4': Pointers cannot reference marshaled structures.  Use ByRef instead.
   at Nefarius.Utilities.DeviceManagement.PnP.SetupApi.DiInstallDevice(HWND hwndParent, HDEVINFO deviceInfoSet, SP_DEVINFO_DATA* deviceInfoData, SP_DRVINFO_DATA* driverInfoData, UInt32 flags, Boolean& needReboot)
   at Nefarius.Utilities.DeviceManagement.PnP.PnPDevice.InstallNullDriver(Boolean& rebootRequired)
   at Nefarius.Utilities.DeviceManagement.PnP.PnPDevice.InstallNullDriver()
```

.NET 6 is unaffected and works fine either way.