### PR TITLE
Update dependencies and refactor PInvoke calls to use Span-based patterns

### DIFF
--- a/Tests/Tests.csproj
+++ b/Tests/Tests.csproj
@@ -9,14 +9,14 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.1"/>
-        <PackageReference Include="NUnit" Version="4.5.1" />
-        <PackageReference Include="NUnit3TestAdapter" Version="6.1.0"/>
-        <PackageReference Include="NUnit.Analyzers" Version="4.12.0">
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.6.0"/>
+        <PackageReference Include="NUnit" Version="4.6.1" />
+        <PackageReference Include="NUnit3TestAdapter" Version="6.2.0"/>
+        <PackageReference Include="NUnit.Analyzers" Version="4.13.0">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
-        <PackageReference Include="coverlet.collector" Version="8.0.1">
+        <PackageReference Include="coverlet.collector" Version="10.0.1">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>

--- a/src/Generator/DeviceManagementPropertiesGenerator.csproj
+++ b/src/Generator/DeviceManagementPropertiesGenerator.csproj
@@ -13,15 +13,15 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="5.0.0" PrivateAssets="all" />
-        <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="4.14.0">
+        <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="5.3.0" PrivateAssets="all" />
+        <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="5.3.0">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
-        <PackageReference Include="Microsoft.Windows.CsWin32" Version="0.3.213">
+        <PackageReference Include="Microsoft.Windows.CsWin32" Version="0.3.279">
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>
-        <PackageReference Include="Microsoft.Windows.SDK.Win32Metadata" Version="65.0.8-preview" />
+        <PackageReference Include="Microsoft.Windows.SDK.Win32Metadata" Version="70.0.11-preview" />
         <PackageReference Include="Microsoft.Windows.WDK.Win32Metadata" Version="0.13.25-experimental" />
     </ItemGroup>
 

--- a/src/Nefarius.Utilities.DeviceManagement.csproj
+++ b/src/Nefarius.Utilities.DeviceManagement.csproj
@@ -26,10 +26,10 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.Windows.CsWin32" Version="0.3.213">
+        <PackageReference Include="Microsoft.Windows.CsWin32" Version="0.3.279">
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>
-        <PackageReference Include="Microsoft.Windows.SDK.Win32Metadata" Version="65.0.8-preview">
+        <PackageReference Include="Microsoft.Windows.SDK.Win32Metadata" Version="70.0.11-preview">
             <PrivateAssets>all</PrivateAssets>
         </PackageReference>
         <PackageReference Include="Microsoft.Windows.WDK.Win32Metadata" Version="0.13.25-experimental">
@@ -47,7 +47,7 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.SourceLink.GitHub" Version="10.0.201" PrivateAssets="All"/>
+        <PackageReference Include="Microsoft.SourceLink.GitHub" Version="10.0.300" PrivateAssets="All"/>
     </ItemGroup>
 
     <ItemGroup>

--- a/src/PnP/Devcon.cs
+++ b/src/PnP/Devcon.cs
@@ -521,15 +521,13 @@ public static class Devcon
     public static unsafe bool Update(string hardwareId, string fullInfPath,
         out bool rebootRequired)
     {
-        BOOL reboot = false;
-
         BOOL ret = PInvoke.UpdateDriverForPlugAndPlayDevices(
             HWND.Null,
             hardwareId,
             fullInfPath,
             UPDATEDRIVERFORPLUGANDPLAYDEVICES_FLAGS.INSTALLFLAG_FORCE |
             UPDATEDRIVERFORPLUGANDPLAYDEVICES_FLAGS.INSTALLFLAG_NONINTERACTIVE,
-            &reboot
+            out BOOL reboot
         );
 
         rebootRequired = reboot > 0;

--- a/src/PnP/DeviceClassFilters.cs
+++ b/src/PnP/DeviceClassFilters.cs
@@ -174,9 +174,9 @@ public sealed class DeviceClassFilters
         WIN32_ERROR status = PInvoke.RegQueryValueEx(
             key,
             filter,
-            &type,
+            out type,
             null,
-            &sizeRequired
+            ref sizeRequired
         );
 
         // value exists
@@ -187,9 +187,9 @@ public sealed class DeviceClassFilters
             status = PInvoke.RegQueryValueEx(
                 key,
                 filter,
-                &type,
-                buffer,
-                &sizeRequired
+                out type,
+                new Span<byte>(buffer, (int)sizeRequired),
+                ref sizeRequired
             );
 
             if (status != WIN32_ERROR.ERROR_SUCCESS)
@@ -268,9 +268,9 @@ public sealed class DeviceClassFilters
         WIN32_ERROR status = PInvoke.RegQueryValueEx(
             key,
             filter,
-            &type,
+            out type,
             null,
-            &sizeRequired
+            ref sizeRequired
         );
 
         // value exists
@@ -281,9 +281,9 @@ public sealed class DeviceClassFilters
             status = PInvoke.RegQueryValueEx(
                 key,
                 filter,
-                &type,
-                buffer,
-                &sizeRequired
+                out type,
+                new Span<byte>(buffer, (int)sizeRequired),
+                ref sizeRequired
             );
 
             if (status != WIN32_ERROR.ERROR_SUCCESS)
@@ -341,9 +341,9 @@ public sealed class DeviceClassFilters
         WIN32_ERROR status = PInvoke.RegQueryValueEx(
             key,
             filter,
-            &type,
+            out type,
             null,
-            &sizeRequired
+            ref sizeRequired
         );
 
         switch (status)
@@ -356,9 +356,9 @@ public sealed class DeviceClassFilters
                     status = PInvoke.RegQueryValueEx(
                         key,
                         filter,
-                        &type,
-                        buffer,
-                        &sizeRequired
+                        out type,
+                        new Span<byte>(buffer, (int)sizeRequired),
+                        ref sizeRequired
                     );
 
                     if (status != WIN32_ERROR.ERROR_SUCCESS)

--- a/src/PnP/PnPDevice.Properties.cs
+++ b/src/PnP/PnPDevice.Properties.cs
@@ -348,7 +348,7 @@ public partial class PnPDevice
             _instanceHandle,
             propertyKey,
             out propertyType,
-            (byte*)valueBuffer.ToPointer(),
+            new Span<byte>((byte*)valueBuffer.ToPointer(), (int)valueBufferSize),
             ref valueBufferSize,
             0
         );

--- a/src/PnP/PnPDevice.Static.cs
+++ b/src/PnP/PnPDevice.Static.cs
@@ -84,7 +84,7 @@ public partial class PnPDevice
             symbolicLink,
             property,
             out _,
-            (byte*)buffer,
+            new Span<byte>((byte*)buffer, (int)sizeRequired),
             ref sizeRequired,
             0
         );

--- a/src/PnP/UsbPnPDevice.cs
+++ b/src/PnP/UsbPnPDevice.cs
@@ -131,11 +131,8 @@ public class UsbPnPDevice : PnPDevice
                 BOOL success = PInvoke.DeviceIoControl(
                     hubHandle,
                     PInvoke.IOCTL_USB_HUB_CYCLE_PORT,
-                    &parameters,
-                    (uint)size,
-                    &parameters,
-                    (uint)size,
-                    null,
+                    new ReadOnlySpan<byte>((byte*)&parameters, size),
+                    new Span<byte>((byte*)&parameters, size),
                     null
                 );
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated NuGet dependencies to latest versions across test and source projects, including test frameworks, code analysis tools, and Windows SDK packages.

* **Refactor**
  * Modernized platform interop code to use safer span-based buffer handling and explicit output parameters instead of raw pointer operations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/nefarius/Nefarius.Utilities.DeviceManagement/pull/147?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->