### PR TITLE
Implement DEVPROP marshalling for mapped but unsupported types

### DIFF
--- a/Tests/Unit/DevicePropertyMarshalTests.cs
+++ b/Tests/Unit/DevicePropertyMarshalTests.cs
@@ -1,6 +1,9 @@
 using System.Runtime.InteropServices;
 
+using Windows.Win32.Foundation;
+
 using Nefarius.Utilities.DeviceManagement.Internal;
+using Nefarius.Utilities.DeviceManagement.PnP;
 
 namespace Tests.Unit;
 
@@ -49,15 +52,67 @@ public class DevicePropertyMarshalTests
     }
 
     [Test]
+    public void RoundTrip_Binary()
+    {
+        RoundTrip(new byte[] { 0x00, 0x01, 0x03, 0x00, 0x05 }, typeof(byte[]));
+        RoundTrip(Array.Empty<byte>(), typeof(byte[]));
+    }
+
+    [Test]
+    public void RoundTrip_FloatingPoint()
+    {
+        RoundTrip(-1.5f, typeof(float));
+        RoundTrip(3.14159f, typeof(float));
+        RoundTrip(-2.5d, typeof(double));
+        RoundTrip(6.02214076d, typeof(double));
+    }
+
+    [Test]
+    public void RoundTrip_Decimal()
+    {
+        RoundTrip(0m, typeof(decimal));
+        RoundTrip(1234.5678m, typeof(decimal));
+        RoundTrip(-1234.5678m, typeof(decimal));
+    }
+
+    [Test]
+    public void RoundTrip_DateTime()
+    {
+        DateTime value = new(2024, 6, 1, 12, 0, 0, DateTimeKind.Unspecified);
+        RoundTrip(value, typeof(DateTime));
+    }
+
+    [Test]
+    public void RoundTrip_DevPropKey()
+    {
+        DEVPROPKEY value = new()
+        {
+            fmtid = Guid.Parse("{83DA6326-97A6-4088-9453-A1923F573B29}"),
+            pid = 15
+        };
+        RoundTrip(value, typeof(DEVPROPKEY));
+    }
+
+    [Test]
+    public void NativeToManagedTypeMap_IsFullySupported()
+    {
+        foreach (Type managedType in PnPDevice.NativeToManagedTypeMap.Values.Distinct())
+        {
+            Assert.That(DevicePropertyMarshal.IsSupported(managedType), Is.True,
+                $"NativeToManagedTypeMap advertises {managedType} but DevicePropertyMarshal cannot convert it.");
+        }
+    }
+
+    [Test]
     public void Write_UnsupportedType_Throws()
     {
         Assert.Multiple(() =>
         {
             Assert.That(
-                () => DevicePropertyMarshal.Write(1.5f, typeof(float), out _),
+                () => DevicePropertyMarshal.Write(TimeSpan.Zero, typeof(TimeSpan), out _),
                 Throws.TypeOf<NotImplementedException>());
             Assert.That(
-                () => DevicePropertyMarshal.Read(IntPtr.Zero, 0, typeof(float)),
+                () => DevicePropertyMarshal.Read(IntPtr.Zero, 0, typeof(TimeSpan)),
                 Throws.TypeOf<NotImplementedException>());
         });
     }
@@ -77,6 +132,10 @@ public class DevicePropertyMarshalTests
             else if (managedType == typeof(DateTimeOffset))
             {
                 Assert.That(((DateTimeOffset)read).ToFileTime(), Is.EqualTo(((DateTimeOffset)value).ToFileTime()));
+            }
+            else if (managedType == typeof(DateTime))
+            {
+                Assert.That(((DateTime)read).ToOADate(), Is.EqualTo(((DateTime)value).ToOADate()));
             }
             else
             {

--- a/Tests/Unit/DevicePropertyMarshalTests.cs
+++ b/Tests/Unit/DevicePropertyMarshalTests.cs
@@ -59,6 +59,18 @@ public class DevicePropertyMarshalTests
     }
 
     [Test]
+    public void Write_EmptyByteArray_ReturnsNullBuffer()
+    {
+        IntPtr buffer = DevicePropertyMarshal.Write(Array.Empty<byte>(), typeof(byte[]), out uint size);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(buffer, Is.EqualTo(IntPtr.Zero));
+            Assert.That(size, Is.Zero);
+        });
+    }
+
+    [Test]
     public void RoundTrip_FloatingPoint()
     {
         RoundTrip(-1.5f, typeof(float));
@@ -144,7 +156,10 @@ public class DevicePropertyMarshalTests
         }
         finally
         {
-            Marshal.FreeHGlobal(buffer);
+            if (buffer != IntPtr.Zero)
+            {
+                Marshal.FreeHGlobal(buffer);
+            }
         }
     }
 }

--- a/src/Generator/DeviceManagementPropertiesGenerator.csproj
+++ b/src/Generator/DeviceManagementPropertiesGenerator.csproj
@@ -13,8 +13,8 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="5.9.0" PrivateAssets="all" />
-        <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="5.9.0">
+        <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="5.6.0" PrivateAssets="all" />
+        <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="5.6.0">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>

--- a/src/Internal/DevicePropertyMarshal.cs
+++ b/src/Internal/DevicePropertyMarshal.cs
@@ -2,6 +2,8 @@ using System;
 using System.Linq;
 using System.Runtime.InteropServices;
 
+using Windows.Win32.Foundation;
+
 using Nefarius.Utilities.DeviceManagement.Util;
 
 namespace Nefarius.Utilities.DeviceManagement.Internal;
@@ -11,6 +13,32 @@ namespace Nefarius.Utilities.DeviceManagement.Internal;
 /// </summary>
 internal static class DevicePropertyMarshal
 {
+    /// <summary>
+    ///     Returns whether <paramref name="managedType" /> can be converted by <see cref="Read" /> and <see cref="Write" />.
+    /// </summary>
+    internal static bool IsSupported(Type managedType)
+    {
+        return managedType == typeof(string)
+               || managedType == typeof(string[])
+               || managedType == typeof(sbyte)
+               || managedType == typeof(byte)
+               || managedType == typeof(short)
+               || managedType == typeof(ushort)
+               || managedType == typeof(int)
+               || managedType == typeof(uint)
+               || managedType == typeof(long)
+               || managedType == typeof(ulong)
+               || managedType == typeof(float)
+               || managedType == typeof(double)
+               || managedType == typeof(decimal)
+               || managedType == typeof(DateTime)
+               || managedType == typeof(DateTimeOffset)
+               || managedType == typeof(Guid)
+               || managedType == typeof(bool)
+               || managedType == typeof(byte[])
+               || managedType == typeof(DEVPROPKEY);
+    }
+
     /// <summary>
     ///     Reads a managed value from a native property buffer.
     /// </summary>
@@ -66,6 +94,32 @@ internal static class DevicePropertyMarshal
             return (ulong)Marshal.ReadInt64(buffer);
         }
 
+        if (managedType == typeof(float))
+        {
+            return BitConverter.ToSingle(ReadBytes(buffer, sizeof(float)), 0);
+        }
+
+        if (managedType == typeof(double))
+        {
+            return BitConverter.ToDouble(ReadBytes(buffer, sizeof(double)), 0);
+        }
+
+        if (managedType == typeof(decimal))
+        {
+            // OLE DECIMAL: wReserved(2) scale(1) sign(1) Hi32(4) Lo64(8).
+            byte scale = Marshal.ReadByte(buffer, 2);
+            byte sign = Marshal.ReadByte(buffer, 3);
+            int hi = Marshal.ReadInt32(buffer, 4);
+            long lo64 = Marshal.ReadInt64(buffer, 8);
+
+            return new decimal((int)(lo64 & 0xFFFFFFFF), (int)(lo64 >> 32), hi, (sign & 0x80) != 0, scale);
+        }
+
+        if (managedType == typeof(DateTime))
+        {
+            return DateTime.FromOADate(BitConverter.ToDouble(ReadBytes(buffer, sizeof(double)), 0));
+        }
+
         if (managedType == typeof(DateTimeOffset))
         {
             return DateTimeOffset.FromFileTime(Marshal.ReadInt64(buffer));
@@ -76,9 +130,24 @@ internal static class DevicePropertyMarshal
             return Marshal.PtrToStructure<Guid>(buffer);
         }
 
+        if (managedType == typeof(DEVPROPKEY))
+        {
+            return Marshal.PtrToStructure<DEVPROPKEY>(buffer);
+        }
+
         if (managedType == typeof(bool))
         {
             return Marshal.ReadByte(buffer) != 0;
+        }
+
+        if (managedType == typeof(byte[]))
+        {
+            if (size == 0)
+            {
+                return Array.Empty<byte>();
+            }
+
+            return ReadBytes(buffer, (int)size);
         }
 
         throw new NotImplementedException($"Type {managedType} not supported.");
@@ -88,6 +157,9 @@ internal static class DevicePropertyMarshal
     ///     Allocates and fills a native property buffer for the given managed value.
     ///     Caller must free the returned pointer with <see cref="Marshal.FreeHGlobal" />.
     /// </summary>
+    /// <remarks>
+    ///     A zero-length <see cref="byte" />[] buffer makes <c>CM_Set_DevNode_Property</c> delete the property.
+    /// </remarks>
     public static IntPtr Write(object propertyValue, Type managedType, out uint propBufSize)
     {
         if (managedType == typeof(string))
@@ -170,6 +242,42 @@ internal static class DevicePropertyMarshal
             return buffer;
         }
 
+        if (managedType == typeof(float))
+        {
+            return WriteBytes(BitConverter.GetBytes((float)propertyValue), out propBufSize);
+        }
+
+        if (managedType == typeof(double))
+        {
+            return WriteBytes(BitConverter.GetBytes((double)propertyValue), out propBufSize);
+        }
+
+        if (managedType == typeof(decimal))
+        {
+            decimal value = (decimal)propertyValue;
+            int[] bits = decimal.GetBits(value);
+            int lo = bits[0];
+            int mid = bits[1];
+            int hi = bits[2];
+            byte scale = (byte)((bits[3] >> 16) & 0xFF);
+            byte sign = (bits[3] & unchecked((int)0x80000000)) != 0 ? (byte)0x80 : (byte)0;
+
+            propBufSize = 16;
+            IntPtr buffer = Marshal.AllocHGlobal((int)propBufSize);
+            Marshal.WriteInt16(buffer, 0, 0);
+            Marshal.WriteByte(buffer, 2, scale);
+            Marshal.WriteByte(buffer, 3, sign);
+            Marshal.WriteInt32(buffer, 4, hi);
+            Marshal.WriteInt64(buffer, 8, ((long)mid << 32) | (uint)lo);
+            return buffer;
+        }
+
+        if (managedType == typeof(DateTime))
+        {
+            DateTime value = (DateTime)propertyValue;
+            return WriteBytes(BitConverter.GetBytes(value.ToOADate()), out propBufSize);
+        }
+
         if (managedType == typeof(DateTimeOffset))
         {
             DateTimeOffset value = (DateTimeOffset)propertyValue;
@@ -188,6 +296,15 @@ internal static class DevicePropertyMarshal
             return buffer;
         }
 
+        if (managedType == typeof(DEVPROPKEY))
+        {
+            DEVPROPKEY value = (DEVPROPKEY)propertyValue;
+            propBufSize = (uint)Marshal.SizeOf<DEVPROPKEY>();
+            IntPtr buffer = Marshal.AllocHGlobal((int)propBufSize);
+            Marshal.StructureToPtr(value, buffer, false);
+            return buffer;
+        }
+
         if (managedType == typeof(bool))
         {
             propBufSize = sizeof(byte);
@@ -196,6 +313,31 @@ internal static class DevicePropertyMarshal
             return buffer;
         }
 
+        if (managedType == typeof(byte[]))
+        {
+            byte[] value = (byte[])propertyValue;
+            return WriteBytes(value, out propBufSize);
+        }
+
         throw new NotImplementedException($"Type {managedType} not supported.");
+    }
+
+    private static byte[] ReadBytes(IntPtr buffer, int length)
+    {
+        byte[] value = new byte[length];
+        Marshal.Copy(buffer, value, 0, length);
+        return value;
+    }
+
+    private static IntPtr WriteBytes(byte[] bytes, out uint propBufSize)
+    {
+        propBufSize = (uint)bytes.Length;
+        IntPtr buffer = Marshal.AllocHGlobal(bytes.Length == 0 ? 1 : bytes.Length);
+        if (bytes.Length > 0)
+        {
+            Marshal.Copy(bytes, 0, buffer, bytes.Length);
+        }
+
+        return buffer;
     }
 }

--- a/src/Internal/DevicePropertyMarshal.cs
+++ b/src/Internal/DevicePropertyMarshal.cs
@@ -158,7 +158,8 @@ internal static class DevicePropertyMarshal
     ///     Caller must free the returned pointer with <see cref="Marshal.FreeHGlobal" />.
     /// </summary>
     /// <remarks>
-    ///     A zero-length <see cref="byte" />[] buffer makes <c>CM_Set_DevNode_Property</c> delete the property.
+    ///     A zero-length <see cref="byte" />[] returns <see cref="IntPtr.Zero" /> and size 0. Combined with
+    ///     <c>DEVPROP_TYPE_EMPTY</c> that is the native contract for deleting the property.
     /// </remarks>
     public static IntPtr Write(object propertyValue, Type managedType, out uint propBufSize)
     {
@@ -316,6 +317,12 @@ internal static class DevicePropertyMarshal
         if (managedType == typeof(byte[]))
         {
             byte[] value = (byte[])propertyValue;
+            if (value.Length == 0)
+            {
+                propBufSize = 0;
+                return IntPtr.Zero;
+            }
+
             return WriteBytes(value, out propBufSize);
         }
 

--- a/src/PnP/PnPDevice.Properties.cs
+++ b/src/PnP/PnPDevice.Properties.cs
@@ -120,6 +120,10 @@ public partial class PnPDevice
     /// <typeparam name="T">The type of the property.</typeparam>
     /// <param name="propertyKey">The <see cref="DevicePropertyKey" /> to update.</param>
     /// <param name="propertyValue">The value to set.</param>
+    /// <remarks>
+    ///     Passing an empty <see cref="byte" />[] deletes the property via <c>DEVPROP_TYPE_EMPTY</c>, a null buffer, and
+    ///     size 0. Non-empty arrays are written as <c>DEVPROP_TYPE_BINARY</c>.
+    /// </remarks>
     public unsafe void SetProperty<T>(DevicePropertyKey propertyKey, T propertyValue)
     {
         if (typeof(T) != propertyKey.PropertyType)
@@ -138,13 +142,18 @@ public partial class PnPDevice
 
         IntPtr buffer = DevicePropertyMarshal.Write(propertyValue!, managedType, out uint propBufSize);
 
+        if (managedType == typeof(byte[]) && propBufSize == 0)
+        {
+            nativePropType = DEVPROPTYPE.DEVPROP_TYPE_EMPTY;
+        }
+
         try
         {
             CONFIGRET ret = PInvoke.CM_Set_DevNode_Property(
                 _instanceHandle,
                 &nativePropKey,
                 nativePropType,
-                (byte*)buffer.ToPointer(),
+                buffer == IntPtr.Zero ? null : (byte*)buffer.ToPointer(),
                 propBufSize,
                 0
             );
@@ -156,7 +165,10 @@ public partial class PnPDevice
         }
         finally
         {
-            Marshal.FreeHGlobal(buffer);
+            if (buffer != IntPtr.Zero)
+            {
+                Marshal.FreeHGlobal(buffer);
+            }
         }
     }
 

--- a/src/PnP/PnPDevice.Properties.cs
+++ b/src/PnP/PnPDevice.Properties.cs
@@ -15,7 +15,7 @@ namespace Nefarius.Utilities.DeviceManagement.PnP;
 
 public partial class PnPDevice
 {
-    private static readonly IDictionary<DEVPROPTYPE, Type> NativeToManagedTypeMap =
+    internal static readonly IDictionary<DEVPROPTYPE, Type> NativeToManagedTypeMap =
         new Dictionary<DEVPROPTYPE, Type>
         {
             { DEVPROPTYPE.DEVPROP_TYPE_SBYTE, typeof(sbyte) },


### PR DESCRIPTION
## Summary
- `DevicePropertyMarshal` now round-trips `byte[]`, `float`, `double`, `decimal`, `DateTime`, and `DEVPROPKEY`, matching `NativeToManagedTypeMap`.
- `GetProperty<byte[]>` no longer throws `NotImplementedException`, which is what hid DsHidMini ControlApp identification rows.
- Added a map/marshal consistency test and retargeted the unsupported-type case off `float`.
- Pinned the source generator to CodeAnalysis 5.6 so the .NET 10 SDK compiler can load it.

## Test plan
- [x] `dotnet test Tests\Tests.csproj -c Release --filter Category=Unit|Category=CI` (48 passed on SDK 10.0.301)
- [x] CI `build.yml` Unit/CI job
- [ ] After merge, tag `v6.1.0` so `publish-to-nuget.yml` ships the package

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Device properties now support binary data, floating-point values, decimals, dates, and property keys when reading and writing.
  - Empty binary values can be used to delete a device property.
  - Improved handling of zero-length property data and date/value conversions.

- **Bug Fixes**
  - Expanded validation helps ensure supported device-property types are handled consistently and reliably.
  - Improved handling of empty native buffers prevents errors when device properties contain no data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->